### PR TITLE
Add PR script

### DIFF
--- a/bin/git-pr
+++ b/bin/git-pr
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [[ "$(git rev-list --count $(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')..HEAD)" == "1" ]]; then
+  git push --force-with-lease && gh pr create --fill "$@"
+else
+  echo "Multiple commits..."
+  git push --force-with-lease && gh pr create "$@"
+fi


### PR DESCRIPTION
Taken from [Geoff][1]. Thank you @geoffharcourt

I ran into something odd that required me to adjust the script a little
bit. I was running the commands to see what they did.

```
$ git rev-list --count HEAD ^main             #=> 114
$ git rev-list --count HEAD ^origin/main      #=> 1
$ git rev-list --count main..HEAD             #=> 1
```

HEAD is on a branch that is one commit ahead of `main`:

```
eeb5ec8 (HEAD -> add-pr-script, origin/add-pr-script) Add PR script
eeb51fa (origin/main, origin/HEAD, main) Move some hotkeys to a "prefix tree"
```

`git-rev-list`’s man page says

> A special notation “<commit1>..<commit2>” can be used as a short-hand
> for “^<commit1> <commit2>“. For example, either of the following may
> be used interchangeably:
>
>         $ git rev-list origin..HEAD
>         $ git rev-list HEAD ^origin

I changed the script to use the `main..HEAD` option, but I’m not sure
why I’m getting 114 back if both commands are supposed to be
interchangeable.

[1]: https://github.com/geoffharcourt/dotfiles-local/blob/6459ae43dbc22018f6a3fd6662564c00e06253c6/bin/pr
